### PR TITLE
Update code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: check-added-large-files
       - id: check-json
@@ -10,7 +10,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 21.11b1
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/make_webshots.py
+++ b/make_webshots.py
@@ -121,6 +121,15 @@ class Webshotter:
             f" got {login_text!r}"
         )
         login_button.click()
+        continue_button = WebDriverWait(self.driver, 300).until(
+            EC.presence_of_element_located((By.XPATH, "//button[@type='submit']"))
+        )
+        txt = continue_button.text.strip().lower()
+        assert txt == "continue", (
+            "'Continue' button did not have expected text; expected 'Continue',"
+            f" got {txt!r}"
+        )
+        continue_button.click()
         WebDriverWait(self.driver, 300).until(
             EC.presence_of_element_located((By.ID, "login_field"))
         )

--- a/make_webshots.py
+++ b/make_webshots.py
@@ -354,7 +354,7 @@ def click_edit(driver):
     # TODO: more sensible way to "identify" it:
     # https://github.com/dandi/dandiarchive/issues/648
     edit_button = WebDriverWait(driver, 3).until(
-        EC.element_to_be_clickable((By.XPATH, '//a[@id="view-edit-metadata"]'))
+        EC.element_to_be_clickable((By.XPATH, '//button[@id="view-edit-metadata"]'))
     )
     edit_button.click()
 

--- a/make_webshots.py
+++ b/make_webshots.py
@@ -121,15 +121,6 @@ class Webshotter:
             f" got {login_text!r}"
         )
         login_button.click()
-        continue_button = WebDriverWait(self.driver, 300).until(
-            EC.presence_of_element_located((By.XPATH, "//button[@type='submit']"))
-        )
-        txt = continue_button.text.strip().lower()
-        assert txt == "continue", (
-            "'Continue' button did not have expected text; expected 'Continue',"
-            f" got {txt!r}"
-        )
-        continue_button.click()
         WebDriverWait(self.driver, 300).until(
             EC.presence_of_element_located((By.ID, "login_field"))
         )


### PR DESCRIPTION
Closes #14.

This PR:
- ~updates the login procedure for a change on GitHub's end~ (and then undoes the change, as it became unnecessary again)
- [x] updates the XPATH used to locate the "View/Edit Metadata" button
- ~updates the check for waiting for file listings to load~ (Deferred to later PR for issue #16)