### PR TITLE
A collection of fixes and workarounds 

### DIFF
--- a/make_webshots.py
+++ b/make_webshots.py
@@ -278,6 +278,8 @@ class FlakeyFeeder:
     def __exit__(self, _exc_type, _exc_val, _exc_tb):
         if self.process is not None:
             self.pipe.close()
+            log.debug("Closed the pipe")
+            time.sleep(1)  # seems to be critical for closing the browser
             if self.process.is_alive():
                 log.debug("Terminating subprocess")
                 self.process.terminate()

--- a/make_webshots.py
+++ b/make_webshots.py
@@ -214,11 +214,11 @@ class Webshotter:
             try:
                 if urlsuf is not None:
                     log.debug("Before get")
-                    self.driver.get(f"{self.gui_url}/#/dandiset/{ds}{urlsuf}")
+                    self.driver.get(f"{self.gui_url}/dandiset/{ds}{urlsuf}")
                     log.debug("After get")
                 else:
                     log.debug("Before get")
-                    self.driver.get(f"{self.gui_url}/#/dandiset/{ds}")
+                    self.driver.get(f"{self.gui_url}/dandiset/{ds}")
                     log.debug("After get")
                     log.debug("Before initial wait")
                     self.wait_no_progressbar("v-progress-circular")
@@ -384,7 +384,7 @@ def snapshot_pipe(dandi_instance, gui_url, log_level, c1, conn):
                         label="Edit Metadata"
                         if page == "edit-metadata"
                         else "Go to page",
-                        url=f"{gui_url}/#/dandiset/{ds}{urlsuf}"
+                        url=f"{gui_url}/dandiset/{ds}{urlsuf}"
                         if urlsuf is not None
                         else None,
                     )

--- a/make_webshots.py
+++ b/make_webshots.py
@@ -359,7 +359,9 @@ def click_edit(driver):
 PAGES = {
     "landing": ("", "v-progress-circular", None),
     "edit-metadata": (None, "v-progress-circular", click_edit),
-    "view-data": ("/draft/files", "v-progress-linear", None),
+    # TODO: remove ?location= after https://github.com/dandi/dandi-archive/issues/1058
+    # is fixed
+    "view-data": ("/draft/files?location=", "v-progress-linear", None),
 }
 
 


### PR DESCRIPTION
individual commits have more details in their description.

primary motivation to have addressed is #16 to which I have not come up with an ideal solution. The whole web ui is "blinking" now into its existence which takes some time unfortunately, can't even rely on seeing those progress bars.  (issue against dandi-archive is  https://github.com/dandi/dandi-archive/issues/1060)

along the way possibly improved solution for #12 by adding a sleep.

for better DX added a few options to help with troubleshooting locally

I will now run  a sweep across all dandisets using this version